### PR TITLE
Add hint to not use LIMIT in "Simple aggregation"

### DIFF
--- a/questions/basic/00110000-agg.ex
+++ b/questions/basic/00110000-agg.ex
@@ -1,7 +1,7 @@
 |QUESTIONNAME|
 Simple aggregation
 |QUESTION|
-You'd like to get the signup date of your last member.  How can you retrieve this information?
+You'd like to get the signup date of your last member.  How can you retrieve this information? Try to do it without using the <c>LIMIT</c> operator.
 |QUERY|
 select max(joindate) as latest
 	from cd.members;


### PR DESCRIPTION
Noticed that this question is easily solvable without using the `MAX` function as intended:

```sql
select joindate as latest from cd.members order by joindate desc limit 1
```

This just adds an extra line telling answerers not to use `LIMIT` (similar to the hint [on a previous question](https://pgexercises.com/questions/basic/where4.html)).