### PR TITLE
Update 00041875-fachoursbymonth2.ex to use EXTRACT

### DIFF
--- a/questions/aggregates/00041875-fachoursbymonth2.ex
+++ b/questions/aggregates/00041875-fachoursbymonth2.ex
@@ -5,9 +5,7 @@ Produce a list of the total number of slots booked per facility per month in the
 |QUERY|
 select facid, extract(month from starttime) as month, sum(slots) as "Total Slots"
 	from cd.bookings
-	where
-		starttime >= '2012-01-01'
-		and starttime < '2013-01-01'
+	where extract(year from starttime) = 2012
 	group by facid, month
 order by facid, month;
 |ANSWER|


### PR DESCRIPTION
I think EXRACT should be used in the WHERE clause, instead of inequalities, since it's newly introduced in this exercise and leads to a more succinct query.