### PR TITLE
update to evergreen link for PG docs

### DIFF
--- a/site/website/index.html
+++ b/site/website/index.html
@@ -66,7 +66,7 @@
       </div>
     
       <div class="row" style="margin-bottom:30px">
-          <div class="span8"><p>Welcome to PostgreSQL Exercises! This site was born when I noticed that there's a load of material out there to help people learn about SQL, but not a great deal to make it easy to learn by doing.  PGExercises provides a series of questions and explanations built on a single, simple dataset. It's designed for use as a partner to a good book or Postgres' excellent <a href="http://www.postgresql.org/docs/9.3/interactive/index.html">documentation</a>.</p>
+          <div class="span8"><p>Welcome to PostgreSQL Exercises! This site was born when I noticed that there's a load of material out there to help people learn about SQL, but not a great deal to make it easy to learn by doing.  PGExercises provides a series of questions and explanations built on a single, simple dataset. It's designed for use as a partner to a good book or Postgres' excellent <a href="https://www.postgresql.org/docs/current/index.html">documentation</a>.</p>
           <p>The exercises on this site range from simple select and where clauses, through joins and case statements, and on to aggregations, window functions, and recursive queries.  Most people who aren't already pros should find something to test themselves with.</p>
           <p>For an introduction to the dataset, go to <a href="gettingstarted.html">Getting Started</a>, then select an exercise category from the menu and go!</p></div>
       </div>


### PR DESCRIPTION
New link is evergreen; old link was for 9.3, which is now unsupported.