### PR TITLE
Sum, not count — lines 6-7

### DIFF
--- a/questions/date/00090000-bookingspermonth.ex
+++ b/questions/date/00090000-bookingspermonth.ex
@@ -3,7 +3,8 @@ Return a count of bookings for each month
 |QUESTION|
 Return a count of bookings for each month, sorted by month
 |QUERY|
-select date_trunc('month', starttime) as month, count(*)
+select date_trunc('month', starttime) as month,
+        sum(slots)
 	from cd.bookings
 	group by month
 	order by month


### PR DESCRIPTION
Business will want to know the sum of all reservations rather than the sum of boolean 1's for when there was at least one reservation.