### PR TITLE
fix wording on joins/self

### DIFF
--- a/questions/joins/00030000-self.ex
+++ b/questions/joins/00030000-self.ex
@@ -1,7 +1,7 @@
 |QUESTIONNAME|
-Produce a list of all members who have recommended another member
+Produce a list of all members who were recommended by another member
 |QUESTION|
-How can you output a list of all members who have recommended another member?  Ensure that there are no duplicates in the list, and that results are ordered by (surname, firstname).
+How can you output a list of all members who were recommended by another member?  Ensure that there are no duplicates in the list, and that results are ordered by (surname, firstname).
 |QUERY|
 select distinct recs.firstname as firstname, recs.surname as surname
 	from 


### PR DESCRIPTION
The original question asks for a list of members that recommended another member, but it expects a list of members that were recommended by another member.
This PR aligns the wording of the question to the expected result.