### PR TITLE
When a correct answer is submitted, automatically scroll down to discussions

### DIFF
--- a/site/website/js/site.js
+++ b/site/website/js/site.js
@@ -337,6 +337,16 @@ function query(str) {
 
 				$("#youranswertickspan").empty();
 				$("#youranswertickspan").append($('<img class="youranswertick" src="../../assets/tick2.svg">'));
+				
+				//After correct answer, automatically scroll down to discussions 
+				let scrollTimeInMillis = 800;
+				let finalElementId = 'querydiv';
+				setTimeout(() => {
+					document.getElementById(finalElementId)?.scrollIntoView(
+						{behavior: 'smooth'}
+					);
+				}, scrollTimeInMillis)
+
 			} else {
 				$("#youranswertickspan").empty();
 				$("#youranswertickspan").append($('<img class="youranswertick" src="../../assets/cross.svg">'));

--- a/site/website/js/site.js
+++ b/site/website/js/site.js
@@ -339,7 +339,7 @@ function query(str) {
 				$("#youranswertickspan").append($('<img class="youranswertick" src="../../assets/tick2.svg">'));
 				
 				//After correct answer, automatically scroll down to discussions 
-				let scrollTimeInMillis = 800;
+				let scrollTimeInMillis = 2000;
 				let finalElementId = 'querydiv';
 				setTimeout(() => {
 					document.getElementById(finalElementId)?.scrollIntoView(


### PR DESCRIPTION
Minor cosmetic change - when a correct answer is provided, a user either reads discussions (and the expected solution) or moves to the next problem.  
We can automatically scroll down to the discussions div, where the "Next Exercise" button also becomes visible.  

Sample recording (_some frames have been skipped in the recording, the scrolling is smoother than it appears_)  



https://user-images.githubusercontent.com/45961072/213865022-3b2436e0-a401-46f3-9f1b-399b62d6ff92.mp4

